### PR TITLE
Add What Font Finder (image-based font identifier)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A curated list of fonts and typography resources.
 * [Font Of Web](https://fontofweb.com) - Fonts from the most inspiring websites on the web
 * [Fonts In Use](https://fontsinuse.com/) - A public archive of typography
 * [FontsWiki](https://fontswiki.com/) - Free font downloads, pairing guides, and font-in-use references for logos, movies, games, and design projects
+* [What Font Finder](https://whatfontfinder.com/font-identifier/) - Identify a font from an image in the browser, with a confidence score and no upload
 * [Typewolf](https://www.typewolf.com/)
 
 ## Free fonts


### PR DESCRIPTION
Link: https://whatfontfinder.com/font-identifier/

Adding one resource: a font identifier that works from an **image** rather than from a page's CSS — a screenshot, a poster, a logo — which is the case where you cannot just inspect the source.

Two things that distinguish it from the identifiers usually listed:

- **It runs entirely in the browser.** The image is never uploaded to a server.
- **Every match carries a confidence score**, so a close hit is distinguishable from a guess.

Free, no account, no watermark, no paid tier.

Thanks for maintaining the list.
